### PR TITLE
correct license wording in advisory board minutes

### DIFF
--- a/minutes/002-2016-q3.md
+++ b/minutes/002-2016-q3.md
@@ -226,7 +226,7 @@ contributors.
 
 The library reimplementation work is done "clean room" style, using
 Oracle documentation but without ever consulting Oracle code (since
-their license is GPL but Scala Native is BSD-style).  There was some
+their license is GPL but Scala Native is BSD 3-clause).  There was some
 discussion among the board about the legal issues around clean room
 implementations. Dag suggested looking at the
 [contributor questionnaire from the Apache Harmony project](http://harmony.apache.org/auth_cont_quest.html)
@@ -321,8 +321,8 @@ sbt).  These topics could eventually become concrete proposals.
 
 #### The Scala license
 
-Bill summarized Sam's licensing concern as follows.  Scala has
-[its own BSD-style license](http://www.scala-lang.org/license.html),
+Bill summarized Sam's licensing concern as follows.  Scala uses
+[the BSD 3-clause license](http://www.scala-lang.org/license.html),
 which doesn't mention patents.  The Scala CLA does address patents.
 "This is concerning because there is no guarantee to recipients of the
 Scala compiler and standard libraries that they have the right to use


### PR DESCRIPTION
Scala's license is absolutely standard BSD 3-clause, not merely
"BSD-style"