### PR TITLE
clarify a position

### DIFF
--- a/minutes/002-2016-q3.md
+++ b/minutes/002-2016-q3.md
@@ -334,7 +334,7 @@ be changed to a Apache 2 license?
 
 Heather said she forwarded Sam's questions to the EPFL technology
 transfer office and in their opinion, having the separate CLA doesn't
-cause any major legal loopholes or problems.
+cause any major legal loopholes or problems for EPFL.
 
 Seth wanted a clearer writeup of what the problem is and what
 the proposed fix us.  Relicensing would be hard, so we need


### PR DESCRIPTION
It is not completely obvious from the sentence to whom the advice was given. Of course, EPFL lawyers / commercialisation departments can only advise their clients, and are not at liberty to advise the Scala community. This small amendment clarifies that the advise was given from the EPFL perspective.