### PR TITLE
keep the minutes in one place only

### DIFF
--- a/minutes/README.md
+++ b/minutes/README.md
@@ -1,0 +1,2 @@
+Newer minutes are at
+https://github.com/scala/scala.epfl.ch/tree/master/minutes/_posts


### PR DESCRIPTION
we want them on the Scala Center site, and if they're there, we
shouldn't duplicate them here