### PR TITLE
feature: automate the creation of proposals/README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.scala/
+.bsp/
+.metals/

--- a/README.md
+++ b/README.md
@@ -30,12 +30,35 @@ Proposals should follow the format and sections laid out in the [template
 proposal](https://github.com/scalacenter/advisoryboard/tree/main/templates/proposal.md),
 and should be concise enough to fit on a single side of paper if printed out.
 
-## Recommendations
+### Recommendations
 
 Once a proposal has been adopted by the Advisory Board, it will become a
 recommendation, and should be copied, noting any amendments, into the
 [recommendations](https://github.com/scalacenter/advisoryboard/tree/main/recommendations)
 directory.
+
+### Proposals status
+
+To see the up-to-date status of a proposal see the
+[proposals/README](./proposals/README.md) which holds a summary of updates and
+statuses of all proposals.
+
+_NOTE_: This proposals/README.md file is auto-generated, so if you need to add
+an update or change the status of a proposal make sure to do so in the heading
+of the proposal file. The possible headings are:
+
+```yaml
+date: date proposed
+accepted: true, yes, false, no
+updates:
+  - postponed until next meeting
+  - accepted after discussion
+  - Updates found at https://www.scala-lang.org/blog/
+status: completed, postponed, active, etc
+```
+
+To regenerate the proposals/README.md file run `scala-cli run bin/` from the
+root of this project.
 
 ## Invitations
 

--- a/bin/.scalafmt.conf
+++ b/bin/.scalafmt.conf
@@ -1,0 +1,8 @@
+version = "3.3.1"
+runner.dialect = scala3
+
+rewrite.scala3.convertToNewSyntax = yes
+rewrite.scala3.removeOptionalBraces = yes
+rewrite.scala3.insertEndMarkerMinLines = 15
+
+docstrings.wrap = no

--- a/bin/generate-proposal-listing.scala
+++ b/bin/generate-proposal-listing.scala
@@ -1,0 +1,143 @@
+// using scala 3.1.0
+// using lib com.vladsch.flexmark:flexmark-all:0.62.2
+
+import java.io.PrintWriter
+import java.io.File
+import java.nio.file.Paths
+import java.util.Collection
+
+import com.vladsch.flexmark.ext.yaml.front.matter.AbstractYamlFrontMatterVisitor
+import com.vladsch.flexmark.ext.yaml.front.matter.YamlFrontMatterExtension
+import com.vladsch.flexmark.parser.{Parser as FlexParser}
+import com.vladsch.flexmark.util.ast.Document
+import com.vladsch.flexmark.util.data.MutableDataSet
+import com.vladsch.flexmark.util.misc.Extension
+
+import scala.jdk.CollectionConverters.*
+import scala.io.Source
+
+/** This is a https://scala-cli.virtuslab.org/ script to iterate through all
+  *  the proposals, grab their front matter and then generate the
+  *  proposals/README.md file.
+  */
+@main def generate() =
+  val wd = Paths.get(".")
+
+  val proposalDir = Paths.get(".", "proposals").toFile
+
+  assert(
+    proposalDir.isDirectory,
+    """|Looks like you're not in the root of this project.
+       |Run scala-cli from the root.
+       |
+       |scala-cli run bin/""".stripMargin
+  )
+
+  for
+    file <- proposalDir.listFiles.sorted
+    if file.isFile &&
+      file.getName.endsWith(".md") &&
+      file.getName.startsWith("0")
+  do
+    val contents = Source
+      .fromFile(file)
+      .getLines
+      .mkString(Printer.newline)
+    val document = Parser.parser.parse(contents)
+    val (date, accepted, updates, status) = Parser.retrieveMetaData(document)
+    Printer.printName(file)
+    Printer.printDate(file, date)
+    Printer.printAccepted(file, accepted)
+    Printer.printUpdates(file, updates)
+    Printer.printStatus(file, status)
+  end for
+
+  Printer.printWarning()
+  Printer.close()
+
+end generate
+
+object Printer:
+  private val pw = new PrintWriter(new File("proposals", "README.md"))
+
+  def close() = pw.close()
+
+  // Just for sanity, let's force unix and not use System.lineSeparator or
+  // anything like that.
+  val newline = "\n"
+  val tab = "\t"
+
+  def printName(file: File) =
+    pw.write(s"# [${file.getName}](./${file.getName})$newline")
+
+  def printDate(file: File, date: Option[String]) =
+    date match
+      case Some(d) => pw.write(s"* Date proposed: $d$newline")
+      case _       => println(s"Missing date for ${file.getName}")
+
+  def printAccepted(file: File, accepted: Option[String]) =
+    accepted match
+      case Some("true" | "yes") => pw.write(s"* Accepted: yes$newline")
+      case Some("false" | "no") => pw.write(s"* Accepted: no$newline")
+      case Some(_) =>
+        println("Invalid value for accepted. Use either true, yes, false, no")
+      case _ => println(s"Missing accepted value for ${file.getName}")
+
+  def printUpdates(file: File, updates: Option[List[String]]) =
+    updates match
+      case Some(u) =>
+        pw.write(s"* Updates:$newline")
+        u.foreach(update => pw.write(s"$tab* $update$newline"))
+      case None => println(s"No updates found for ${file.getName}")
+
+  def printStatus(file: File, status: Option[String]) =
+    status match
+      case Some(s) => pw.write(s"* Status: **$s**$newline")
+      case _       => println(s"Missing status for ${file.getName}")
+
+  def printWarning() =
+    pw.write(
+      s"${newline}_This file is auto-generated. Don't edit here, instead run scala-cli run bin/ to regenerate._"
+    )
+
+end Printer
+
+object Parser:
+  val rawExtensions: List[Extension] = List(
+    YamlFrontMatterExtension.create()
+  )
+
+  val extensions: Collection[Extension] = rawExtensions.asJava
+
+  val options =
+    new MutableDataSet()
+      .set(FlexParser.EXTENSIONS, extensions)
+
+  val parser = FlexParser.builder(options).build()
+
+  def retrieveMetaData(node: Document) =
+    val visitor = new AbstractYamlFrontMatterVisitor()
+    visitor.visit(node)
+    val data = visitor.getData.asScala
+
+    val metadata = visitor
+      .getData()
+      .asScala
+      .toMap
+      .collect {
+        case (key, value) if value.asScala.toList.nonEmpty =>
+          key -> value.asScala.toList
+      }
+
+    // These are all the current values we pull from the header. If you want to
+    // add another in the future all you should need to do is get the key here.
+    // Keep in mind the YAML front matter only supports subset of YAML
+    // https://github.com/vsch/flexmark-java/wiki/Extensions#yaml-front-matter
+    val date = metadata.get("date").flatMap(_.headOption)
+    val accepted = metadata.get("accepted").flatMap(_.headOption)
+    val updates = metadata.get("updates")
+    val status = metadata.get("status").flatMap(_.headOption)
+
+    (date, accepted, updates, status)
+  end retrieveMetaData
+end Parser

--- a/proposals/001-native-scala-for-spark.md
+++ b/proposals/001-native-scala-for-spark.md
@@ -1,3 +1,13 @@
+---
+date: May 2016
+accepted: true
+updates:
+  - deferred for later consideration
+  - considered again and accepted August 2016
+  - dormant no recent activity as of August 2019
+status: dormant
+---
+
 # SCP-001: Native Execution of Scala/Spark via LLVM
 
 ## Proposer

--- a/proposals/002-dotty-migration-path.md
+++ b/proposals/002-dotty-migration-path.md
@@ -1,3 +1,11 @@
+---
+date: May 2016
+accepted: true
+updates:
+  - Remains active as of August 2019
+status: active
+---
+
 # SCP-002: Migration path to Dotty for Scalac users
 
 ## Proposer

--- a/proposals/003-scala-center-publicity-chair.md
+++ b/proposals/003-scala-center-publicity-chair.md
@@ -1,3 +1,11 @@
+---
+date: May 2016
+accepted: true
+updates:
+  - Remains active as of August 2019
+status: active
+---
+
 # SCP-003: Scala Center Publicity Chair
 
 ## Proposer

--- a/proposals/004-sip-and-slip-coordination.md
+++ b/proposals/004-sip-and-slip-coordination.md
@@ -1,3 +1,11 @@
+---
+date: May 2016
+accepted: true
+updates:
+  - SIP coordinator is Darja
+status: active
+---
+
 # SCP-004: Center to coordinate SIP/SLIP process
 
 ## Note

--- a/proposals/005-continuity-of-scala-js.md
+++ b/proposals/005-continuity-of-scala-js.md
@@ -1,3 +1,11 @@
+---
+date: May 2016
+accepted: true
+updates:
+  - Remains active as of August 2019
+status: active
+---
+
 # SCP-005: Ensurance of continuity of Scala.js project
 
 ## Note

--- a/proposals/006-compile-time-serializibility-check.md
+++ b/proposals/006-compile-time-serializibility-check.md
@@ -1,3 +1,11 @@
+---
+date: August 2016
+accepted: true
+updates:
+  - Completed in 2016
+status: completed
+---
+
 # SCP-006: Compile Time Check of Serializability
 
 ## Proposer

--- a/proposals/007-collections.md
+++ b/proposals/007-collections.md
@@ -1,3 +1,11 @@
+---
+date: November 2016
+accepted: true
+updates:
+  - Completed in 2019 with the release of 2.13
+status: completed
+---
+
 # SCP-007: Collaborative redesign and implementation of Scala 2.13's collections library.
 
 ## Proposer

--- a/proposals/008-websites.md
+++ b/proposals/008-websites.md
@@ -1,3 +1,9 @@
+---
+date: November 2016
+accepted: true
+status: active
+---
+
 # SCP-008: Maintain scala-lang, docs.scala-lang, scala.epfl.ch websites
 
 ## Proposer

--- a/proposals/009-improve-direct-dependency-experience.md
+++ b/proposals/009-improve-direct-dependency-experience.md
@@ -1,3 +1,11 @@
+---
+date: November 2016
+accepted: true
+updates:
+  - Completed in 2017
+status: completed
+---
+
 # SCP-009: Improve user experience for builds that use only direct dependencies
 
 ## Proposer

--- a/proposals/010-compiler-profiling.md
+++ b/proposals/010-compiler-profiling.md
@@ -1,3 +1,11 @@
+---
+date: May 2017
+accepted: true
+updates:
+  - Completed in 2018
+status: completed
+---
+
 # Providing Better Compilation Performance Information
 
 ## Proposer

--- a/proposals/011-debugging-symbols.md
+++ b/proposals/011-debugging-symbols.md
@@ -1,3 +1,12 @@
+---
+date: May 2017
+accepted: false
+updates:
+  - Was postponed after discussion
+  - Superseded by a sequel proposal: SCP-022
+status: superseded
+---
+
 # Debugging Position Information
 
 ## Proposer

--- a/proposals/012-improve-sbt-learning-materials.md
+++ b/proposals/012-improve-sbt-learning-materials.md
@@ -1,3 +1,11 @@
+---
+date: May 2017
+accepted: false
+updates:
+  - Withdrawn after discussion
+status: withdrawn
+---
+
 # Improve Resources for Learning SBT
 
 ## Proposer

--- a/proposals/013-sbt-migration.md
+++ b/proposals/013-sbt-migration.md
@@ -1,3 +1,11 @@
+---
+date: September 2017
+accepted: true
+updates:
+  - Migration largely complete as of August 2019
+status: completed
+---
+
 # SCP-013: Aid the ecosystem in upgrading to sbt 1.0.x
 
 ## Proposer

--- a/proposals/014-production-ready-scalamacros.md
+++ b/proposals/014-production-ready-scalamacros.md
@@ -1,3 +1,11 @@
+---
+date: September 2017
+accepted: true
+updates:
+  - In the sense that designs were discussed, trials were made, and conclusions were reached: no substantial changes in Scala 2; design and implementation work on Scala 3 macros remains ongoing at LAMP
+status: completed
+---
+
 # SCP-014: Production ready scalamacros/scalamacros
 
 ## Proposer

--- a/proposals/015-zinc-performance.md
+++ b/proposals/015-zinc-performance.md
@@ -1,3 +1,11 @@
+---
+date: September 2017
+accepted: true
+updates:
+  - Completed in 2018
+status: completed
+---
+
 # SCP-015: Improving performance and profiling of Zinc
 
 ## Proposer

--- a/proposals/016-verbal-descriptions.md
+++ b/proposals/016-verbal-descriptions.md
@@ -1,3 +1,11 @@
+---
+date: March 2018
+accepted: true
+updates:
+  - Completed in 2018
+status: completed
+---
+
 # SCP-016: Accessible Scala
 
 ## Proposer

--- a/proposals/017-lsp-stp-wg-support.md
+++ b/proposals/017-lsp-stp-wg-support.md
@@ -1,3 +1,12 @@
+---
+date: March 2018
+accepted: true
+updates:
+  - Working groups are dormant
+  - Engineering work remains active
+status: dormant/active
+---
+
 # Scala Center Support for LSP and STP Working Groups
 
 ## Proposer

--- a/proposals/018-converging-214-30.md
+++ b/proposals/018-converging-214-30.md
@@ -1,3 +1,11 @@
+---
+date: September 2018
+accepted: true
+updates:
+  - Completed, but in modified form: Scala 2.14 is no longer planned; Dotty is already able to consume Scala 2 artifacts; and the Center has completed a modification of Scala 2.13 to read TASTy so it can consume Scala 3 artifacts
+status: completed
+---
+
 # SCP-018: Converging the Intermediate Representation of Scala 2.14 and Scala 3.0
 
 ## Proposer

--- a/proposals/019-scala-214-30-back-compat.md
+++ b/proposals/019-scala-214-30-back-compat.md
@@ -1,3 +1,8 @@
+---
+date: September 2018
+accepted: false
+---
+
 # SCP-019: Focusing on backwards compatibility for Scala 2.14 and Scala 3.0
 
 ## Proposer

--- a/proposals/020-sbt-transitive-dependencies-conflicts.md
+++ b/proposals/020-sbt-transitive-dependencies-conflicts.md
@@ -1,3 +1,11 @@
+---
+date: December 2018
+accepted: true
+updates:
+  - see https://www.scala-lang.org/2019/10/17/dependency-management.html
+status: completed
+---
+
 # SBT transitive dependency conflicts management improvements
 
 ## Proposer

--- a/proposals/021-zinc-improvements.md
+++ b/proposals/021-zinc-improvements.md
@@ -1,3 +1,9 @@
+---
+date: December 2019
+accepted: true
+status: active
+---
+
 # SCP-021: Zinc improvements
 
 ## Proposer

--- a/proposals/022-jsr-45.md
+++ b/proposals/022-jsr-45.md
@@ -1,3 +1,9 @@
+---
+date: December 2019
+accepted: true
+status: active
+---
+
 # SCP-022: Completing SCP-11: implement JSR-45 for improved Scala debugging experience
 
 ## Proposer

--- a/proposals/023-bsp.md
+++ b/proposals/023-bsp.md
@@ -1,3 +1,10 @@
+---
+date: March 2020
+accepted: true
+updates:
+    - see https://www.scala-lang.org/blog/2020/10/27/bsp-in-sbt.html
+status: completed
+---
 # SCP-023: Build Server Protocol Support for sbt
 
 ## Proposer

--- a/proposals/024-diversity.md
+++ b/proposals/024-diversity.md
@@ -1,3 +1,9 @@
+---
+date: June 2020
+accepted: true
+status: active
+---
+
 # SCP-024: Scala Center Diversity Initiatives
 
 ## Proposer

--- a/proposals/025-inclusive-language.md
+++ b/proposals/025-inclusive-language.md
@@ -1,3 +1,9 @@
+---
+date: October 2020
+accepted: true
+status: active
+---
+
 # SCP-025: Use of Inclusive Language
 
 ## Proposer

--- a/proposals/026-solidify-getting-started-with-coursier.md
+++ b/proposals/026-solidify-getting-started-with-coursier.md
@@ -1,3 +1,9 @@
+---
+date: June 2021
+accepted: true
+status: active
+---
+
 # Solidify Getting Started with Coursier
 
 ## Proposer

--- a/proposals/027-refactoring.md
+++ b/proposals/027-refactoring.md
@@ -1,3 +1,8 @@
+---
+date: November 2021
+status: awaiting revision
+---
+
 ## Proposer
 
 Proposed by Eugene Yokota, Twitter, November 1st, 2021

--- a/proposals/README.md
+++ b/proposals/README.md
@@ -1,146 +1,150 @@
-# 001-native-scala-for-spark.md
+# [001-native-scala-for-spark.md](./001-native-scala-for-spark.md)
+* Date proposed: May 2016
+* Accepted: yes
+* Updates:
+	* deferred for later consideration
+	* considered again and accepted August 2016
+	* dormant no recent activity as of August 2019
+* Status: **dormant**
+# [002-dotty-migration-path.md](./002-dotty-migration-path.md)
+* Date proposed: May 2016
+* Accepted: yes
+* Updates:
+	* Remains active as of August 2019
+* Status: **active**
+# [003-scala-center-publicity-chair.md](./003-scala-center-publicity-chair.md)
+* Date proposed: May 2016
+* Accepted: yes
+* Updates:
+	* Remains active as of August 2019
+* Status: **active**
+# [004-sip-and-slip-coordination.md](./004-sip-and-slip-coordination.md)
+* Date proposed: May 2016
+* Accepted: yes
+* Updates:
+	* SIP coordinator is Darja
+* Status: **active**
+# [005-continuity-of-scala-js.md](./005-continuity-of-scala-js.md)
+* Date proposed: May 2016
+* Accepted: yes
+* Updates:
+	* Remains active as of August 2019
+* Status: **active**
+# [006-compile-time-serializibility-check.md](./006-compile-time-serializibility-check.md)
+* Date proposed: August 2016
+* Accepted: yes
+* Updates:
+	* Completed in 2016
+* Status: **completed**
+# [007-collections.md](./007-collections.md)
+* Date proposed: November 2016
+* Accepted: yes
+* Updates:
+	* Completed in 2019 with the release of 2.13
+* Status: **completed**
+# [008-websites.md](./008-websites.md)
+* Date proposed: November 2016
+* Accepted: yes
+* Status: **active**
+# [009-improve-direct-dependency-experience.md](./009-improve-direct-dependency-experience.md)
+* Date proposed: November 2016
+* Accepted: yes
+* Updates:
+	* Completed in 2017
+* Status: **completed**
+# [010-compiler-profiling.md](./010-compiler-profiling.md)
+* Date proposed: May 2017
+* Accepted: yes
+* Updates:
+	* Completed in 2018
+* Status: **completed**
+# [011-debugging-symbols.md](./011-debugging-symbols.md)
+* Date proposed: May 2017
+* Accepted: no
+* Updates:
+	* Was postponed after discussion
+	* Superseded by a sequel proposal: SCP-022
+* Status: **superseded**
+# [012-improve-sbt-learning-materials.md](./012-improve-sbt-learning-materials.md)
+* Date proposed: May 2017
+* Accepted: no
+* Updates:
+	* Withdrawn after discussion
+* Status: **withdrawn**
+# [013-sbt-migration.md](./013-sbt-migration.md)
+* Date proposed: September 2017
+* Accepted: yes
+* Updates:
+	* Migration largely complete as of August 2019
+* Status: **completed**
+# [014-production-ready-scalamacros.md](./014-production-ready-scalamacros.md)
+* Date proposed: September 2017
+* Accepted: yes
+* Updates:
+	* In the sense that designs were discussed, trials were made, and conclusions were reached: no substantial changes in Scala 2; design and implementation work on Scala 3 macros remains ongoing at LAMP
+* Status: **completed**
+# [015-zinc-performance.md](./015-zinc-performance.md)
+* Date proposed: September 2017
+* Accepted: yes
+* Updates:
+	* Completed in 2018
+* Status: **completed**
+# [016-verbal-descriptions.md](./016-verbal-descriptions.md)
+* Date proposed: March 2018
+* Accepted: yes
+* Updates:
+	* Completed in 2018
+* Status: **completed**
+# [017-lsp-stp-wg-support.md](./017-lsp-stp-wg-support.md)
+* Date proposed: March 2018
+* Accepted: yes
+* Updates:
+	* Working groups are dormant
+	* Engineering work remains active
+* Status: **dormant/active**
+# [018-converging-214-30.md](./018-converging-214-30.md)
+* Date proposed: September 2018
+* Accepted: yes
+* Updates:
+	* Completed, but in modified form: Scala 2.14 is no longer planned; Dotty is already able to consume Scala 2 artifacts; and the Center has completed a modification of Scala 2.13 to read TASTy so it can consume Scala 3 artifacts
+* Status: **completed**
+# [019-scala-214-30-back-compat.md](./019-scala-214-30-back-compat.md)
+* Date proposed: September 2018
+* Accepted: no
+# [020-sbt-transitive-dependencies-conflicts.md](./020-sbt-transitive-dependencies-conflicts.md)
+* Date proposed: December 2018
+* Accepted: yes
+* Updates:
+	* see https://www.scala-lang.org/2019/10/17/dependency-management.html
+* Status: **completed**
+# [021-zinc-improvements.md](./021-zinc-improvements.md)
+* Date proposed: December 2019
+* Accepted: yes
+* Status: **active**
+# [022-jsr-45.md](./022-jsr-45.md)
+* Date proposed: December 2019
+* Accepted: yes
+* Status: **active**
+# [023-bsp.md](./023-bsp.md)
+* Date proposed: March 2020
+* Accepted: yes
+* Updates:
+	* see https://www.scala-lang.org/blog/2020/10/27/bsp-in-sbt.html
+* Status: **completed**
+# [024-diversity.md](./024-diversity.md)
+* Date proposed: June 2020
+* Accepted: yes
+* Status: **active**
+# [025-inclusive-language.md](./025-inclusive-language.md)
+* Date proposed: October 2020
+* Accepted: yes
+* Status: **active**
+# [026-solidify-getting-started-with-coursier.md](./026-solidify-getting-started-with-coursier.md)
+* Date proposed: June 2021
+* Accepted: yes
+* Status: **active**
+# [027-refactoring.md](./027-refactoring.md)
+* Date proposed: November 2021
+* Status: **awaiting revision**
 
-* proposed May 2016
-* deferred for later consideration
-* considered again and accepted August 2016
-* **dormant** no recent activity as of August 2019
-
-# 002-dotty-migration-path.md
-
-* proposed and accepted May 2016
-* **remains active** as of August 2019
-
-# 003-scala-center-publicity-chair.md
-
-* proposed and accepted May 2016
-* **completed** by the addition of the "community manager" staff position
-* (but now, as of late 2019, instead of an "executive director" and a
-  "community manager", we have an "executive director" and a
-  "technical director")
-
-# 004-sip-and-slip-coordination.md
-
-* proposed and accepted May 2016
-* **remains active**; SIP coordinator is Darja
-
-# 005-continuity-of-scala-js.md
-
-* proposed and accepted May 2016
-* **remains active** as of August 2019
-
-# 006-compile-time-serializibility-check.md
-
-* proposed and accepted August 2016
-* **completed** in 2016
-
-# 007-collections.md
-
-* proposed and accepted November 2016
-* **completed** in 2019 with the release of Scala 2.13
-
-# 008-websites.md
-
-* proposed and accepted November 2016
-* **remains active**
-
-# 009-improve-direct-dependency-experience.md
-
-* proposed and accepted November 2016
-* **completed** in 2017
-
-# 010-compiler-profiling.md
-
-* proposed and accepted May 2017
-* **completed** in 2018
-
-# 011-debugging-symbols.md
-
-* proposed May 2017
-* was postponed, after discussion
-* **superseded** by a sequel proposal: SCP-022
-
-# 012-improve-sbt-learning-materials.md
-
-* proposed May 2017
-* **withdrawn** after discussion
-
-# 013-sbt-migration.md
-
-* proposed and accepted September 2017
-* **completed**, migration largely complete as of August 2019
-
-# 014-production-ready-scalamacros.md
-
-* proposed and accepted September 2017
-* **completed**, in the sense that designs were discussed, trials
-  were made, and conclusions were reached: no substantial changes
-  in Scala 2; design and implementation work on Scala 3 macros remains
-  ongoing at LAMP
-
-# 015-zinc-performance.md
-
-* proposed and accepted September 2017
-* **completed** in 2018
-
-# 016-verbal-descriptions.md
-
-* proposed and accepted March 2018
-* **completed** in 2018
-
-# 017-lsp-stp-wg-support.md
-
-* proposed and accepted March 2018
-* working groups are **dormant**
-* engineering work **remains active**
-
-# 018-converging-214-30.md
-
-* proposed and accepted September 2018
-* **completed**, but in modified form: Scala 2.14
-  is no longer planned; Dotty is already able to consume
-  Scala 2 artifacts; and the Center has completed a modification of Scala 2.13 to read TASTy so it can
-  consume Scala 3 artifacts
-
-# 019-scala-214-30-back-compat.md
-
-* proposed December 2018; **not accepted**
-
-# 020-sbt-transitive-dependencies-conflicts.md
-
-* proposed and accepted December 2018
-* **completed**; see https://www.scala-lang.org/2019/10/17/dependency-management.html
-
-# 021-zinc-improvements.md
-
-* proposed and accepted December 2019
-* **remains active**
-
-# 022-jsr-45.md
-
-* proposed and accepted December 2019
-* **remains active**
-
-# 023-bsp.md
-
-* proposed and accepted March 2020
-* **completed**; see https://www.scala-lang.org/blog/2020/10/27/bsp-in-sbt.html
-
-# 024-diversity.md
-
-* proposed and accepted June 2020
-* **remains active**
-
-# 025-inclusive-language.md
-
-* proposed and accepted October 2020
-* **remains active**
-
-# 026-solidify-getting-started-with-coursier.md
-
-* proposed and accepted June 2021
-* **remains active**
-
-# 027-refactoring.md
-
-* proposed, then withdrawn for revision in November 2021
-* **awaiting revision**
+_This file is auto-generated. Don't edit here, instead run scala-cli run bin/ to regenerate._

--- a/templates/proposal.md
+++ b/templates/proposal.md
@@ -1,3 +1,7 @@
+---
+date: [Date of Proposal]
+---
+
 # [Title of the Proposal]
 
 ## Proposer


### PR DESCRIPTION
While going over the current status of all the proposals and creating
https://github.com/scalacenter/advisoryboard/issues/85 I figured we
could maintain the proposals/README.md a bit different. I can imagine
it's easy to forget to update that so I think instead it might be a good
idea to instead just use headers in the proposal files themselves. This
way all updates to a proposal and to the current status is just done in
the actual proposal, and then the README can get generated.