### PR TITLE
move update to updates for refactoring proposal

### DIFF
--- a/proposals/027-refactoring.md
+++ b/proposals/027-refactoring.md
@@ -1,11 +1,13 @@
 ---
 date: November 2021
 status: awaiting discussion
+updates:
+  - revised March 2022
 ---
 
 ## Proposer
 
-Proposed by Eugene Yokota, Twitter, November 2021 (revised March 2022)
+Proposed by Eugene Yokota, Twitter, November 2021
 
 ## Abstract
 

--- a/proposals/README.md
+++ b/proposals/README.md
@@ -153,6 +153,8 @@
 * Status: **active**
 # [027-refactoring.md](./027-refactoring.md)
 * Date proposed: November 2021
+* Updates:
+	* revised March 2022
 * Status: **awaiting discussion**
 # [028-community-delegate-terms.md](./028-community-delegate-terms.md)
 * Date proposed: January 2022


### PR DESCRIPTION
This just moves the update to the `updates` key so it shows up in the overview readme page.