### PR TITLE
refactor: remove the recommendations dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ consideration only by
  - The Scala Center,
  - advisory board members,
  - affiliate members, or
- - community members,
+ - community members through the community representatives,
 
 and should be made via a pull-request adding a new Markdown file to the
 [proposals](https://github.com/scalacenter/advisoryboard/tree/main/proposals)
@@ -30,19 +30,13 @@ Proposals should follow the format and sections laid out in the [template
 proposal](https://github.com/scalacenter/advisoryboard/tree/main/templates/proposal.md),
 and should be concise enough to fit on a single side of paper if printed out.
 
-### Recommendations
-
-Once a proposal has been adopted by the Advisory Board, it will become a
-recommendation, and should be copied noting any amendments, or linked if
-unchanged into the
-[recommendations](https://github.com/scalacenter/advisoryboard/tree/main/recommendations)
-directory.
-
 ### Proposals status
 
 To see the up-to-date status of a proposal see the
-[proposals/README](./proposals/README.md) which holds a summary of updates and
-statuses of all proposals.
+[proposals/README](./proposals/README.md) which holds whether or not the
+proposal has been accepted, a summary of updates and the current status of all
+proposals. Once a proposal has been accepted by the board it becomes a
+"recommendation".
 
 **NOTE**: This proposals/README.md file is auto-generated, so if you need to add
 an update or change the status of a proposal make sure to do so in the heading
@@ -58,8 +52,9 @@ updates:
 status: completed, postponed, active, etc
 ```
 
-To regenerate the proposals/README.md file run `scala-cli run bin/` from the
-root of this project.
+The proposals/README.md will be updated in CI when merged into `main`, but you
+can also manually regenerate it with `scala-cli run bin/` from the root of this
+project.
 
 ## Invitations
 
@@ -89,5 +84,3 @@ Contributions *may* be made to this repository, however the documents here
 represent a record of the proceedings of Advisory Board meetings, so only
 immaterial changes such as spelling corrections and reformatting will be
 accepted.
-
-

--- a/recommendations/001-native-scala-for-spark.md
+++ b/recommendations/001-native-scala-for-spark.md
@@ -1,1 +1,0 @@
-../proposals/001-native-scala-for-spark.md

--- a/recommendations/002-dotty-migration-path.md
+++ b/recommendations/002-dotty-migration-path.md
@@ -1,1 +1,0 @@
-../proposals/002-dotty-migration-path.md

--- a/recommendations/003-scala-center-publicity-chair.md
+++ b/recommendations/003-scala-center-publicity-chair.md
@@ -1,1 +1,0 @@
-../proposals/003-scala-center-publicity-chair.md

--- a/recommendations/004-sip-and-slip-coordination.md
+++ b/recommendations/004-sip-and-slip-coordination.md
@@ -1,1 +1,0 @@
-../proposals/004-sip-and-slip-coordination.md

--- a/recommendations/005-continuity-of-scala-js.md
+++ b/recommendations/005-continuity-of-scala-js.md
@@ -1,1 +1,0 @@
-../proposals/005-continuity-of-scala-js.md

--- a/recommendations/006-compile-time-serializibility-check.md
+++ b/recommendations/006-compile-time-serializibility-check.md
@@ -1,1 +1,0 @@
-../proposals/006-compile-time-serializibility-check.md

--- a/recommendations/007-collections.md
+++ b/recommendations/007-collections.md
@@ -1,1 +1,0 @@
-../proposals/007-collections.md

--- a/recommendations/008-websites.md
+++ b/recommendations/008-websites.md
@@ -1,1 +1,0 @@
-../proposals/008-websites.md

--- a/recommendations/009-improve-direct-dependency-experience.md
+++ b/recommendations/009-improve-direct-dependency-experience.md
@@ -1,1 +1,0 @@
-../proposals/009-improve-direct-dependency-experience.md

--- a/recommendations/010-compiler-profiling.md
+++ b/recommendations/010-compiler-profiling.md
@@ -1,1 +1,0 @@
-../proposals/010-compiler-profiling.md

--- a/recommendations/011-debugging-symbols.md
+++ b/recommendations/011-debugging-symbols.md
@@ -1,1 +1,0 @@
-../proposals/011-debugging-symbols.md

--- a/recommendations/013-sbt-migration.md
+++ b/recommendations/013-sbt-migration.md
@@ -1,1 +1,0 @@
-../proposals/013-sbt-migration.md

--- a/recommendations/014-production-ready-scalamacros.md
+++ b/recommendations/014-production-ready-scalamacros.md
@@ -1,1 +1,0 @@
-../proposals/014-production-ready-scalamacros.md

--- a/recommendations/015-zinc-performance.md
+++ b/recommendations/015-zinc-performance.md
@@ -1,1 +1,0 @@
-../proposals/015-zinc-performance.md

--- a/recommendations/016-verbal-descriptions.md
+++ b/recommendations/016-verbal-descriptions.md
@@ -1,1 +1,0 @@
-../proposals/016-verbal-descriptions.md

--- a/recommendations/017-lsp-stp-wg-support.md
+++ b/recommendations/017-lsp-stp-wg-support.md
@@ -1,1 +1,0 @@
-../proposals/017-lsp-stp-wg-support.md

--- a/recommendations/018-converging-214-30.md
+++ b/recommendations/018-converging-214-30.md
@@ -1,1 +1,0 @@
-../proposals/018-converging-214-30.md

--- a/recommendations/020-sbt-transitive-dependencies-conflicts.md
+++ b/recommendations/020-sbt-transitive-dependencies-conflicts.md
@@ -1,1 +1,0 @@
-../proposals/020-sbt-transitive-dependencies-conflicts.md

--- a/recommendations/021-zinc-improvements.md
+++ b/recommendations/021-zinc-improvements.md
@@ -1,1 +1,0 @@
-../proposals/021-zinc-improvements.md

--- a/recommendations/022-jsr-45.md
+++ b/recommendations/022-jsr-45.md
@@ -1,1 +1,0 @@
-../proposals/022-jsr-45.md

--- a/recommendations/023-bsp.md
+++ b/recommendations/023-bsp.md
@@ -1,1 +1,0 @@
-../proposals/023-bsp.md

--- a/recommendations/024-diversity.md
+++ b/recommendations/024-diversity.md
@@ -1,1 +1,0 @@
-../proposals/024-diversity.md

--- a/recommendations/025-inclusive-language.md
+++ b/recommendations/025-inclusive-language.md
@@ -1,1 +1,0 @@
-../proposals/025-inclusive-language.md

--- a/recommendations/026-solidify-getting-started-with-coursier.md
+++ b/recommendations/026-solidify-getting-started-with-coursier.md
@@ -1,1 +1,0 @@
-../proposals/026-solidify-getting-started-with-coursier.md

--- a/recommendations/027-refactoring.md
+++ b/recommendations/027-refactoring.md
@@ -1,1 +1,0 @@
-../proposals/027-refactoring.md

--- a/recommendations/028-community-delegate-terms.md
+++ b/recommendations/028-community-delegate-terms.md
@@ -1,1 +1,0 @@
-../proposals/028-community-delegate-terms.md


### PR DESCRIPTION
Since this directory currently contains no extra information from what
can be found in the proposals overview page, this removes all of the
recommendations and instead changes wording in the README to point
towards the proposals/README.md instead.