### PR TITLE
Mark SCP-027 as dormant

### DIFF
--- a/proposals/027-refactoring.md
+++ b/proposals/027-refactoring.md
@@ -1,6 +1,6 @@
 ---
 date: November 2021
-status: accepted
+status: dormant
 updates:
   - revised March 2022
   - A working group will be created to further pull out actionable items from this proposal before any work will begin.


### PR DESCRIPTION
After the proposal was accepted by the board members, the Scala Center created a working group to explore its feasibility and propose a concrete technical solution. We published the results of the working group in #101.

We don’t plan to work more on the proposal anytime soon as we did not perceive much interest from the community or the stakeholders. We believe our resources are better spent on other tasks, as shown in our [roadmap](https://www.scala-lang.org/blog/2023/01/31/scala-center-2023-roadmap.html).