### PR TITLE
mark SCP-033 (deprecate Scala IDE) as completed

### DIFF
--- a/proposals/033-deprecate-scala-ide.md
+++ b/proposals/033-deprecate-scala-ide.md
@@ -1,7 +1,7 @@
 ---
 date: August 2024
 accepted: true
-status: active
+status: completed
 ---
 
 # Deprecate Eclipse Scala IDE

--- a/proposals/README.md
+++ b/proposals/README.md
@@ -192,6 +192,6 @@
 # [033-deprecate-scala-ide.md](./033-deprecate-scala-ide.md)
 * Date proposed: August 2024
 * Accepted: yes
-* Status: **active**
+* Status: **completed**
 
 _This file is auto-generated. Don't edit here, instead run scala-cli run bin/ to regenerate._


### PR DESCRIPTION
not intended for merge until there is consensus that the proposal is actually completed

* [x] transfer ownership of scala-ide.org domain from Lightbend to EPFL
* [x] publish https://docs.scala-lang.org/getting-started/scala-ides.html
* [x] take down the old website http://scala-ide.org and make it redirect to the above page
* [x] update the [forum thread](https://users.scala-lang.org/t/scala-ide-for-eclipse/9095)

@fsalvi could you go ahead with replacing the website with a redirect, as discussed on #159 and agreed upon at the September advisory board meeting?

@zainab-ali @sjrd @lrytz do you agree that we'll be done at that point?