### PR TITLE
add April 2024 advisory board meeting agenda

### DIFF
--- a/agendas/032-2024-q1.md
+++ b/agendas/032-2024-q1.md
@@ -1,0 +1,11 @@
+# Scala Center Advisory Board Meeting, Q1 2024: Agenda
+
+* Welcome (Chris)
+* Welcome JetBrains, Scala plugin for IntelliJ
+* Scala Center Update (Darja)
+* We need to meet in person and discuss the future of the Scala Center, would you be available and when would it be the most convenient
+* Technical Report (Seb)
+* Scala 2 Report (Seth)
+* Updates from the community reps (Eugene/Zainab)
+* Any remaining business
+* Closing remarks (Chris)


### PR DESCRIPTION
I couldn't find it in my email archives, but it was shown on-screen in the meeting video

fyi @ckipp01 